### PR TITLE
[task] Fix issue with imports

### DIFF
--- a/Python/Algorithm.py
+++ b/Python/Algorithm.py
@@ -1,5 +1,10 @@
 import operator
 import copy
+import os
+import sys
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
 
 import DepartmentObj
 from MiscFuncs import getHighestNKeysInDict

--- a/Python/DepartmentObj.py
+++ b/Python/DepartmentObj.py
@@ -1,3 +1,9 @@
+import os
+import sys
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
+
 import Algorithm as alg
 
 """

--- a/Python/ItemObj.py
+++ b/Python/ItemObj.py
@@ -1,3 +1,9 @@
+import os
+import sys
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
+
 from ItemLocObj import ItemLoc
 
 """

--- a/Python/StoreObj.py
+++ b/Python/StoreObj.py
@@ -1,5 +1,9 @@
-#import cv2
 import numpy
+import os
+import sys
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
 
 import MiscFuncs as mc
 

--- a/Python/TestFiles/Algorithm_test.py
+++ b/Python/TestFiles/Algorithm_test.py
@@ -1,4 +1,10 @@
 import unittest
+import os
+import sys
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
+sys.path.append(os.path.join(file_dir, ".."))
 
 from YamlParser import parseTestYamlFile
 from Algorithm import estimateLoc
@@ -15,7 +21,7 @@ class TestAlgorithmMethods(unittest.TestCase):
     that the parser is working properly.
     """
     def testParse(self):
-        stores = parseTestYamlFile("TestParamFiles/Test1.yaml")
+        stores = parseTestYamlFile(os.path.join(file_dir, "..", "TestParamFiles/Test1.yaml"))
 
         for store in stores:
             print(store)
@@ -27,7 +33,7 @@ class TestAlgorithmMethods(unittest.TestCase):
     Output needs to be checked to ensure estimation is working.
     """
     def testEstimateLoc(self):
-        stores = parseTestYamlFile("TestParamFiles/Test1.yaml")
+        stores = parseTestYamlFile(os.path.join(file_dir, "..", "TestParamFiles/Test1.yaml"))
 
         knownItems = []
 

--- a/Python/TestFiles/MiscFuncs_test.py
+++ b/Python/TestFiles/MiscFuncs_test.py
@@ -1,4 +1,10 @@
 import unittest
+import os
+import sys
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
+sys.path.append(os.path.join(file_dir, ".."))
 
 from MiscFuncs import distBetweenPoints, getHighestNKeysInDict
 

--- a/Python/YamlParser.py
+++ b/Python/YamlParser.py
@@ -1,4 +1,9 @@
 import yaml
+import os
+import sys
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
 
 from StoreObj import Store
 from DepartmentObj import Department


### PR DESCRIPTION
Looks like the error causing modules not to be found was due to the search path not being added. This commit adds the source folder to the Python search path.